### PR TITLE
fix: enable pages workflow setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- allow actions/configure-pages to enable Pages for first-time setup

## Test
- npm run build:pages