### PR TITLE
fix standalone file tab editor chrome

### DIFF
--- a/packages/app-server/src/topologySessionManager.ts
+++ b/packages/app-server/src/topologySessionManager.ts
@@ -10,6 +10,9 @@ import type { ClabApiClient } from "./clabApiClient.ts";
 type ContainerDataProvider = ReturnType<typeof createRuntimeContainerDataProvider>;
 type DeploymentState = "deployed" | "undeployed" | "unknown";
 type TopologySourcePreference = "api-file" | "running-lab-doc";
+type DirtyContextHost = {
+  updateContext(context: { dirty: boolean | undefined }): void;
+};
 
 interface SessionRecord {
   baseUrl: string;
@@ -252,7 +255,7 @@ export function createStandaloneTopologySessionManager(): StandaloneTopologySess
         if (!matchesPath && !matchesLabName) {
           continue;
         }
-        session.host.updateContext({ dirty });
+        (session.host as unknown as DirtyContextHost).updateContext({ dirty });
       }
     }
   };

--- a/packages/standalone-runtime/src/standaloneApp.tsx
+++ b/packages/standalone-runtime/src/standaloneApp.tsx
@@ -134,6 +134,18 @@ const LazyFileEditorTabPanel = lazy(async () => {
   return { default: module.FileEditorTabPanel };
 });
 
+const FILE_TAB_TOPOLOGY_CHROME_CSS = `
+  [data-testid="context-panel"],
+  [data-testid="panel-toggle-btn"],
+  [data-testid="panel-toggle-btn"] + * {
+    display: none !important;
+  }
+
+  header.MuiAppBar-root:has([data-testid="navbar-lab-name"]) {
+    display: none !important;
+  }
+`;
+
 const LazySettingsOverlay = lazy(async () => {
   const module = await import("./components/SettingsOverlay");
   return { default: module.SettingsOverlay };
@@ -1971,6 +1983,10 @@ function StandaloneApp() {
     (state) => state.closeImageManager,
   );
   const terminalCount = useRuntimeUiStore((state) => state.terminals.length);
+  const activeLabTabKind = useLabTabsStore((state) => {
+    const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+    return activeTab?.kind ?? null;
+  });
   const runtimeChromeReady = useDeferredRuntimeChrome();
   const runtimeDialogsReady = isPagesRuntimeMode() || runtimeChromeReady;
   usePagesLifecycleControlsHidden();
@@ -2218,6 +2234,9 @@ function StandaloneApp() {
 
   return (
     <>
+      {activeLabTabKind === "file" ? (
+        <style>{FILE_TAB_TOPOLOGY_CHROME_CSS}</style>
+      ) : null}
       <App initialData={initialData} runtime={standaloneRuntime!} />
       <StandaloneLabTabsMount />
       <StandaloneFileEditorTabMount />

--- a/packages/standalone-runtime/src/standaloneDirtyState.ts
+++ b/packages/standalone-runtime/src/standaloneDirtyState.ts
@@ -16,6 +16,20 @@ export interface DirtyStateTarget {
   topologyRef: TopologyRef;
 }
 
+interface DirtyStateStoreCompat {
+  setDirty?: (dirty: boolean | undefined) => void;
+  setInitialData?: (data: { isDirty?: boolean }) => void;
+}
+
+function setTopologyDirtyState(dirty: boolean | undefined): void {
+  const store = useTopoViewerStore.getState() as DirtyStateStoreCompat;
+  if (store.setDirty) {
+    store.setDirty(dirty);
+    return;
+  }
+  store.setInitialData?.(dirty === undefined ? {} : { isDirty: dirty });
+}
+
 export async function refreshTopologyDirtyState(
   target: DirtyStateTarget
 ): Promise<boolean | undefined> {
@@ -44,10 +58,10 @@ export async function refreshTopologyDirtyState(
     // Leave the sync state unknown when the dry-run cannot run.
   }
 
-  useTopoViewerStore.getState().setDirty(dirty);
+  setTopologyDirtyState(dirty);
   return dirty;
 }
 
 export function resetTopologyDirtyState(): void {
-  useTopoViewerStore.getState().setDirty(undefined);
+  setTopologyDirtyState(undefined);
 }

--- a/packages/standalone-runtime/src/standaloneLifecycle.ts
+++ b/packages/standalone-runtime/src/standaloneLifecycle.ts
@@ -19,6 +19,7 @@ import type {
 
 type StandaloneLifecycleCommand =
   | ExtensionLifecycleCommand
+  | "applyLab"
   | "startLab"
   | "stopLab"
   | "restartLab";


### PR DESCRIPTION
## Summary

- Hide topology-specific chrome while a standalone file-editor tab is active, preventing the palette drawer and topology toolbar from staying visible over file tabs.
- Keep dirty-state and apply lifecycle handling compiling against the currently consumed `@srl-labs/clab-ui` package while preserving the newer runtime behavior.
- Propagate topology dirty state through app-server sessions using a narrow compatibility boundary.

## Root Cause

The standalone file editor overlays the topology viewer while the viewer remains mounted. If the topology context panel was open, its persistent drawer could remain visible over the file editor. Separately, standalone code referenced newer `clab-ui` dirty/apply APIs while `containerlab-app` currently consumes older package declarations.

## Validation

- `npm run typecheck`
- `npx oxlint --import-plugin --react-plugin --jsx-a11y-plugin packages/standalone-runtime/src/standaloneDirtyState.ts packages/standalone-runtime/src/standaloneLifecycle.ts packages/standalone-runtime/src/standaloneApp.tsx packages/app-server/src/topologySessionManager.ts`
- `node --import tsx --test packages/app-server/src/topologySessionManager.test.ts packages/standalone-runtime/src/**/*.test.ts`
