### PR TITLE
chore: adopt clab-ui 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,26 +351,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@base-ui/utils": {
-      "version": "0.2.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
       "dev": true,
@@ -1481,10 +1461,6 @@
         "ws": "^8.16.0"
       }
     },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "license": "MIT"
-    },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.10",
       "license": "OFL-1.1",
@@ -1991,43 +1967,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@mui/x-tree-view": {
-      "version": "8.28.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@base-ui/utils": "^0.2.3",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0",
-        "@types/react-transition-group": "^4.4.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
       }
     },
     "node_modules/@oxlint-tsgolint/darwin-arm64": {
@@ -2885,7 +2824,9 @@
       }
     },
     "node_modules/@srl-labs/clab-ui": {
-      "version": "0.2.0",
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@srl-labs/clab-ui/0.3.0/90605c1a6049e8f7f237f1b41e88cf3efe3ce38b",
+      "integrity": "sha512-x3xoi5xIF4V17pgaPsGvoEgXYhAie6z/WodK7N0ErxGnRAwbDdTJm/4LHs6KFfhS0QFXTg1TCa2KpTfCMv+j5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -2894,7 +2835,6 @@
         "@mui/icons-material": "^7.3.10",
         "@mui/material": "^7.3.10",
         "@mui/x-charts": "^8.28.2",
-        "@mui/x-tree-view": "^8.28.3",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.18.0",
         "d3-force": "^3.0.0",
@@ -8542,7 +8482,7 @@
         "@fastify/cors": "^10.1.0",
         "@fastify/static": "^8.3.0",
         "@fastify/websocket": "^11.2.0",
-        "@srl-labs/clab-ui": "0.2.0",
+        "@srl-labs/clab-ui": "0.3.0",
         "@srl-labs/containerlab-app-contract": "0.2.0",
         "fastify": "^5.8.5",
         "ws": "^8.20.0"
@@ -8563,7 +8503,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.10",
         "@mui/material": "^7.3.10",
-        "@srl-labs/clab-ui": "0.2.0",
+        "@srl-labs/clab-ui": "0.3.0",
         "@srl-labs/containerlab-app-contract": "0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",

--- a/packages/app-server/package.json
+++ b/packages/app-server/package.json
@@ -13,7 +13,7 @@
     "@fastify/cors": "^10.1.0",
     "@fastify/static": "^8.3.0",
     "@fastify/websocket": "^11.2.0",
-    "@srl-labs/clab-ui": "0.2.0",
+    "@srl-labs/clab-ui": "0.3.0",
     "@srl-labs/containerlab-app-contract": "0.2.0",
     "fastify": "^5.8.5",
     "ws": "^8.20.0"

--- a/packages/standalone-runtime/package.json
+++ b/packages/standalone-runtime/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.10",
     "@mui/material": "^7.3.10",
-    "@srl-labs/clab-ui": "0.2.0",
+    "@srl-labs/clab-ui": "0.3.0",
     "@srl-labs/containerlab-app-contract": "0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",


### PR DESCRIPTION
- Bump the published `@srl-labs/clab-ui` dependency to `0.3.0` for the standalone app server and runtime packages.
- Refresh the lockfile so web and desktop builds consume the published package artifact.
- Bring the standalone app onto the latest shared TopoViewer/editor behavior used by the VS Code extension release.
