### PR TITLE
fix: support IPv6 web listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,6 @@ USER node
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'; const tls = !['0','false','no','off'].includes(String(process.env.WEB_TLS_ENABLE || 'true').toLowerCase()); fetch((tls ? 'https' : 'http') + '://127.0.0.1:' + (process.env.PORT || '3001') + '/api/config').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));"
+  CMD node -e "process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'; const tls = !['0','false','no','off'].includes(String(process.env.WEB_TLS_ENABLE || 'true').toLowerCase()); fetch((tls ? 'https' : 'http') + '://[::1]:' + (process.env.PORT || '3001') + '/api/config').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));"
 
 CMD ["node", "apps/web/dist/server/index.cjs"]

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -36,7 +36,7 @@ async function start(): Promise<void> {
     viteDevUrl: VITE_DEV_URL
   });
 
-  await app.listen({ port: PORT, host: "0.0.0.0" });
+  await app.listen({ port: PORT, host: "::", ipv6Only: false });
   const protocol = WEB_TLS.enabled ? "https" : "http";
   app.log.info(`Standalone app server running at ${protocol}://localhost:${PORT}`);
   if (WEB_TLS.generated && WEB_TLS.certFile) {


### PR DESCRIPTION
## Summary

- bind the web server to the unspecified IPv6 address with dual-stack support enabled
- use IPv6 loopback for the container health check

## Why

The production web entrypoint was hard-coded to `0.0.0.0`, making the service unreachable in IPv6-only environments. Binding to `::` while leaving `ipv6Only` disabled accepts IPv6 connections and preserves IPv4 compatibility.

Closes #21

## Validation

- `npm run lint --workspace containerlab-app-web`
- `npm run test:unit` (162 passed)
- `npm run build:web`
- smoke-tested `/api/config` over both `::1` and `127.0.0.1`
