### PR TITLE
fix: retain topology sessions and prepare v0.2.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerlab-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Manage and inspect containerlab topologies from a desktop application.",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@srl-labs/containerlab-app-server": "0.2.1"
+    "@srl-labs/containerlab-app-server": "0.2.2"
   },
   "devDependencies": {
     "electron": "^41.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerlab-app-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Browser host for containerlab-app built on @srl-labs/clab-ui.",
   "license": "Apache-2.0",
@@ -40,8 +40,8 @@
     "@fastify/websocket": "^11.3.0",
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
-    "@srl-labs/containerlab-app-server": "0.2.1",
-    "@srl-labs/containerlab-standalone-runtime": "0.2.1",
+    "@srl-labs/containerlab-app-server": "0.2.2",
+    "@srl-labs/containerlab-standalone-runtime": "0.2.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "ajv": "^8.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "containerlab-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "containerlab-app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/*",
@@ -40,10 +40,10 @@
     },
     "apps/desktop": {
       "name": "containerlab-desktop",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@srl-labs/containerlab-app-server": "0.2.1"
+        "@srl-labs/containerlab-app-server": "0.2.2"
       },
       "devDependencies": {
         "electron": "^41.5.0",
@@ -57,7 +57,7 @@
     },
     "apps/web": {
       "name": "containerlab-app-web",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -68,8 +68,8 @@
         "@fastify/websocket": "^11.3.0",
         "@mui/icons-material": "^7.3.11",
         "@mui/material": "^7.3.11",
-        "@srl-labs/containerlab-app-server": "0.2.1",
-        "@srl-labs/containerlab-standalone-runtime": "0.2.1",
+        "@srl-labs/containerlab-app-server": "0.2.2",
+        "@srl-labs/containerlab-standalone-runtime": "0.2.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "ajv": "^8.20.0",
@@ -8588,7 +8588,7 @@
     },
     "packages/app-contract": {
       "name": "@srl-labs/containerlab-app-contract",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^6.0.3"
@@ -8596,7 +8596,7 @@
     },
     "packages/app-server": {
       "name": "@srl-labs/containerlab-app-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cookie": "^11.1.2",
@@ -8604,7 +8604,7 @@
         "@fastify/static": "^8.3.0",
         "@fastify/websocket": "^11.3.0",
         "@srl-labs/clab-ui": "0.3.1",
-        "@srl-labs/containerlab-app-contract": "0.2.1",
+        "@srl-labs/containerlab-app-contract": "0.2.2",
         "fastify": "^5.11.3",
         "ws": "^8.21.3"
       },
@@ -8617,7 +8617,7 @@
     },
     "packages/standalone-runtime": {
       "name": "@srl-labs/containerlab-standalone-runtime",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -8625,7 +8625,7 @@
         "@mui/icons-material": "^7.3.11",
         "@mui/material": "^7.3.11",
         "@srl-labs/clab-ui": "0.3.1",
-        "@srl-labs/containerlab-app-contract": "0.2.1",
+        "@srl-labs/containerlab-app-contract": "0.2.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "containerlab-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Workspace for Containerlab web and desktop hosts.",
   "license": "Apache-2.0",

--- a/packages/app-contract/package.json
+++ b/packages/app-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srl-labs/containerlab-app-contract",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Shared route DTO types for Containerlab app hosts.",
   "license": "Apache-2.0",

--- a/packages/app-server/package.json
+++ b/packages/app-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srl-labs/containerlab-app-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Shared Fastify BFF for Containerlab web and desktop hosts.",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
     "@fastify/static": "^8.3.0",
     "@fastify/websocket": "^11.3.0",
     "@srl-labs/clab-ui": "0.3.1",
-    "@srl-labs/containerlab-app-contract": "0.2.1",
+    "@srl-labs/containerlab-app-contract": "0.2.2",
     "fastify": "^5.11.3",
     "ws": "^8.21.3"
   },

--- a/packages/app-server/src/topologyEventsProxy.test.ts
+++ b/packages/app-server/src/topologyEventsProxy.test.ts
@@ -43,8 +43,15 @@ function ndjsonResponse(lines: string[]): Response {
 async function injectTopologyEvents(options: {
   internalUpdate: boolean;
   lines: string[];
-}): Promise<{ body: string; statusCode: number }> {
+}): Promise<{
+  body: string;
+  leaseAcquired: number;
+  leaseReleased: number;
+  statusCode: number;
+}> {
   const app = Fastify({ logger: false });
+  let leaseAcquired = 0;
+  let leaseReleased = 0;
   let openedLabName = "";
   let openedPath = "";
   let openedToken = "";
@@ -63,6 +70,23 @@ async function injectTopologyEvents(options: {
   } as Pick<ClabApiClient, "openTopologyEventStream"> as ClabApiClient;
 
   const sessions = {
+    acquireSession(id: string, endpointId?: string) {
+      if (id !== sessionId || endpointId !== endpoint.id) {
+        return null;
+      }
+      leaseAcquired += 1;
+      return {
+        session: {
+          endpointId: endpoint.id,
+          isInternalUpdate: () => options.internalUpdate,
+          sessionId,
+          topologyRef
+        },
+        release() {
+          leaseReleased += 1;
+        }
+      };
+    },
     createSession() {
       throw new Error("not used");
     },
@@ -103,6 +127,8 @@ async function injectTopologyEvents(options: {
     assert.equal(openedPath, topologyRef.yamlPath);
     return {
       body: response.body,
+      leaseAcquired,
+      leaseReleased,
       statusCode: response.statusCode
     };
   } finally {
@@ -126,6 +152,8 @@ test("/api/topology/events forwards topology document events outside internal up
   });
 
   assert.equal(response.statusCode, 200, response.body);
+  assert.equal(response.leaseAcquired, 1);
+  assert.equal(response.leaseReleased, 1);
   assert.match(response.body, /:ok/);
   assert.match(response.body, /rev-external/);
 });

--- a/packages/app-server/src/topologyEventsProxy.ts
+++ b/packages/app-server/src/topologyEventsProxy.ts
@@ -104,34 +104,38 @@ export function registerTopologyEventsProxy(
       }
 
       const { client, endpoint } = resolved;
-      const session = sessions.getSession(sessionId, endpoint.id);
-      if (!session) {
+      const sessionLease = sessions.acquireSession(sessionId, endpoint.id);
+      if (!sessionLease) {
         return reply.status(404).send({ error: "Topology session not found" });
       }
-
-      disableStreamTimeouts(request, reply);
-
-      reply.raw.writeHead(
-        200,
-        streamResponseHeaders(request, {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-          "X-Accel-Buffering": "no",
-        }),
-      );
-      reply.raw.write(":ok\n\n");
-      const stopHeartbeat = startSseHeartbeat(reply);
+      const { session } = sessionLease;
 
       let aborted = false;
+      let closeListenerAttached = false;
+      let stopHeartbeat: (() => void) | undefined;
       const abortController = new AbortController();
       const abort = (): void => {
         aborted = true;
         abortController.abort();
       };
-      reply.raw.on("close", abort);
 
       try {
+        disableStreamTimeouts(request, reply);
+
+        reply.raw.writeHead(
+          200,
+          streamResponseHeaders(request, {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+            "X-Accel-Buffering": "no",
+          }),
+        );
+        reply.raw.write(":ok\n\n");
+        stopHeartbeat = startSseHeartbeat(reply);
+        reply.raw.on("close", abort);
+        closeListenerAttached = true;
+
         const response = await client.openTopologyEventStream(
           endpoint.token,
           session.topologyRef.labName,
@@ -159,8 +163,11 @@ export function registerTopologyEventsProxy(
           writeTopologyEventError(reply, message);
         }
       } finally {
-        stopHeartbeat();
-        reply.raw.off("close", abort);
+        stopHeartbeat?.();
+        sessionLease.release();
+        if (closeListenerAttached) {
+          reply.raw.off("close", abort);
+        }
         if (!aborted && !reply.raw.writableEnded) {
           reply.raw.end();
         }

--- a/packages/app-server/src/topologySessionManager.test.ts
+++ b/packages/app-server/src/topologySessionManager.test.ts
@@ -166,6 +166,46 @@ test("topology sessions expose an internal-update grace window after host writes
   }
 });
 
+test("active topology session leases prevent idle cleanup until released", (t) => {
+  t.mock.timers.enable({ apis: ["Date", "setInterval"], now: 1_000 });
+
+  const yamlPath = "labs/demo.clab.yml";
+  const client = new InMemoryClabApiClient({
+    [yamlPath]: "name: demo\ntopology:\n  nodes: {}\n"
+  }) as unknown as ClabApiClient;
+  const manager = createStandaloneTopologySessionManager();
+
+  try {
+    const session = manager.createSession({
+      client,
+      token: "secret-token",
+      endpointId: "endpoint-remote",
+      topologyRef: {
+        topologyId: `standalone:endpoint-remote::${yamlPath}`,
+        labName: "demo",
+        yamlPath,
+        annotationsPath: `${yamlPath}.annotations.json`,
+        source: "standalone"
+      },
+      mode: "edit",
+      deploymentState: "undeployed",
+      containerDataProvider: createRuntimeContainerDataProvider([])
+    });
+
+    const lease = manager.acquireSession(session.sessionId, "endpoint-remote");
+    assert.ok(lease);
+
+    t.mock.timers.tick(6 * 60 * 1000);
+    assert.equal(manager.getSession(session.sessionId, "endpoint-remote"), session);
+
+    lease.release();
+    t.mock.timers.tick(6 * 60 * 1000);
+    assert.equal(manager.getSession(session.sessionId, "endpoint-remote"), null);
+  } finally {
+    manager.disposeAll();
+  }
+});
+
 test("running-lab-doc sessions treat missing annotations as empty and create them on save", async () => {
   const labName = "demo";
   const yamlPath = "/home/alice/.clab/demo/demo.clab.yml";

--- a/packages/app-server/src/topologySessionManager.ts
+++ b/packages/app-server/src/topologySessionManager.ts
@@ -27,6 +27,15 @@ interface SessionRecord {
   disposeInternalUpdateTracker(): void;
 }
 
+interface ManagedSessionRecord extends SessionRecord {
+  activeLeaseCount: number;
+}
+
+interface TopologySessionLease {
+  release(): void;
+  session: SessionRecord;
+}
+
 interface CreateSessionOptions {
   client: ClabApiClient;
   containerDataProvider: ContainerDataProvider;
@@ -48,6 +57,8 @@ interface InternalUpdateTracker {
 }
 
 export interface StandaloneTopologySessionManager {
+  /** Keep a session out of idle cleanup while a long-lived consumer is using it. */
+  acquireSession(sessionId: string, endpointId?: string): TopologySessionLease | null;
   createSession(options: CreateSessionOptions): SessionRecord;
   disposeAll(): void;
   disposeSessionsForEndpoint(endpointId: string): void;
@@ -117,7 +128,7 @@ function createInternalUpdateTracker(): InternalUpdateTracker {
 }
 
 export function createStandaloneTopologySessionManager(): StandaloneTopologySessionManager {
-  const sessions = new Map<string, SessionRecord>();
+  const sessions = new Map<string, ManagedSessionRecord>();
 
   const disposeSessionRecord = (session: SessionRecord): void => {
     session.host.dispose();
@@ -127,7 +138,7 @@ export function createStandaloneTopologySessionManager(): StandaloneTopologySess
   const cleanupExpiredSessions = (): void => {
     const now = Date.now();
     for (const [sessionId, session] of sessions.entries()) {
-      if (now - session.lastAccess <= SESSION_TTL_MS) {
+      if (session.activeLeaseCount > 0 || now - session.lastAccess <= SESSION_TTL_MS) {
         continue;
       }
       disposeSessionRecord(session);
@@ -148,6 +159,31 @@ export function createStandaloneTopologySessionManager(): StandaloneTopologySess
   };
 
   return {
+    acquireSession(sessionId, endpointId) {
+      const session = sessions.get(sessionId);
+      if (!session || (endpointId && session.endpointId !== endpointId)) {
+        return null;
+      }
+
+      session.lastAccess = Date.now();
+      session.activeLeaseCount += 1;
+      let released = false;
+
+      return {
+        session,
+        release() {
+          if (released) {
+            return;
+          }
+          released = true;
+          session.activeLeaseCount = Math.max(0, session.activeLeaseCount - 1);
+          if (sessions.get(sessionId) === session) {
+            session.lastAccess = Date.now();
+          }
+        }
+      };
+    },
+
     createSession(options) {
       const sessionId = globalThis.crypto.randomUUID();
       const fs = new ClabApiFileSystemAdapter({
@@ -175,7 +211,8 @@ export function createStandaloneTopologySessionManager(): StandaloneTopologySess
         }
       });
 
-      const record: SessionRecord = {
+      const record: ManagedSessionRecord = {
+        activeLeaseCount: 0,
         baseUrl: options.client.getBaseUrl(),
         endpointId: options.endpointId,
         host,

--- a/packages/standalone-runtime/package.json
+++ b/packages/standalone-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srl-labs/containerlab-standalone-runtime",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Shared standalone Containerlab renderer/runtime for web and desktop hosts.",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     "@mui/icons-material": "^7.3.11",
     "@mui/material": "^7.3.11",
     "@srl-labs/clab-ui": "0.3.1",
-    "@srl-labs/containerlab-app-contract": "0.2.1",
+    "@srl-labs/containerlab-app-contract": "0.2.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "ajv": "^8.20.0",


### PR DESCRIPTION
## Summary

- add session leases that pause idle cleanup while a long-lived consumer is active
- hold and reliably release a lease for each topology event stream
- cover session cleanup and event-stream lease behavior
- bump the root and all workspaces to `0.2.2`
- synchronize internal workspace dependency pins and lockfile metadata

## Why

Topology sessions use a five-minute idle timeout. A topology event stream can remain open beyond that timeout without otherwise touching the session, allowing periodic cleanup to dispose the session while it is still in use. The lease keeps the session alive for the stream lifetime and resets its idle timestamp when released.

The synchronized version metadata prepares the repository for the `v0.2.2` release workflows and tag checks.

## Impact

Connected topology event streams no longer lose their backing session because of idle cleanup. Explicit endpoint, token, and application shutdown disposal behavior remains unchanged. All application and workspace package metadata now targets `0.2.2`.

## Validation

- `npm run typecheck`
- `npm run lint` — 0 errors
- `npm run test:unit` — 163 tests passed
- `npm run check:release-version`
- `npm run check:deps`
- `git diff --check`
